### PR TITLE
add flags field to keyboard event data

### DIFF
--- a/SharpHook.Sample/SharpHook.Sample.csproj
+++ b/SharpHook.Sample/SharpHook.Sample.csproj
@@ -12,8 +12,6 @@
   <ItemGroup>
     <ProjectReference Include="..\SharpHook.Reactive\SharpHook.Reactive.csproj" />
     <ProjectReference Include="..\SharpHook\SharpHook.csproj" />
-    <TrimmerRootAssembly Include="SharpHook" />
-    <TrimmerRootAssembly Include="SharpHook.Reactive" />
   </ItemGroup>
 
 </Project>

--- a/SharpHook/Native/KeyboardEventData.cs
+++ b/SharpHook/Native/KeyboardEventData.cs
@@ -33,6 +33,11 @@ public struct KeyboardEventData : IEquatable<KeyboardEventData>
     public char KeyChar;
 
     /// <summary>
+    /// The raw key event flags.
+    /// </summary>
+    public ushort Flags;
+
+    /// <summary>
     /// Compares this object to another object for equality.
     /// </summary>
     /// <param name="obj">The object to compare</param>
@@ -67,7 +72,8 @@ public struct KeyboardEventData : IEquatable<KeyboardEventData>
     /// <returns>The string representation of this object.</returns>
     public override string ToString() =>
         $"{nameof(KeyboardEventData)}: {nameof(this.KeyCode)} = {this.KeyCode}; " +
-        $"{nameof(this.RawCode)} = {this.RawCode}; {nameof(this.KeyChar)} = {this.KeyChar}";
+        $"{nameof(this.RawCode)} = {this.RawCode}; {nameof(this.KeyChar)} = {this.KeyChar}; {nameof(this.Flags)} = {this.Flags}" +
+        $"{(this.IsInjectedEvent() ? "; Injected" : "; Normal")}";
 
     /// <summary>
     /// Compares two objects for equality.
@@ -90,4 +96,13 @@ public struct KeyboardEventData : IEquatable<KeyboardEventData>
     /// </returns>
     public static bool operator !=(KeyboardEventData left, KeyboardEventData right) =>
         !(left == right);
+}
+
+public static class KeyboardEventDataExtensions
+{
+    private const int LLKHF_INJECTED = 0x00000010;
+
+    public static bool IsInjectedEvent(this KeyboardEventData data) {
+        return (data.Flags & LLKHF_INJECTED) != 0;
+    }
 }

--- a/SharpHook/SharpHook.xml
+++ b/SharpHook/SharpHook.xml
@@ -920,6 +920,11 @@
             <value>The character of the key.</value>
             <remarks>This field is available only for the <see cref="F:SharpHook.Native.EventType.KeyTyped" /> event.</remarks>
         </member>
+        <member name="F:SharpHook.Native.KeyboardEventData.Flags">
+            <summary>
+            The raw key event flags.
+            </summary>
+        </member>
         <member name="M:SharpHook.Native.KeyboardEventData.Equals(System.Object)">
             <summary>
             Compares this object to another object for equality.


### PR DESCRIPTION
Add flags field to keyboard event data - requires custom build of libuiohook that exposes the flags.

This allows identifying whether the event is an injected based on the LLKHF_INJECTED bit value.